### PR TITLE
feat: relax lint rules

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -78,7 +78,6 @@
     "no-eval": true,
     "no-inferrable-types": false,
     "no-internal-module": true,
-    "no-null-keyword": true,
     "no-require-imports": true,
     "no-shadowed-variable": true,
     "no-string-literal": true,
@@ -121,7 +120,6 @@
       "call-signature",
       "parameter",
       "property-declaration",
-      "variable-declaration",
       "member-variable-declaration"
     ],
     "typedef-whitespace": [


### PR DESCRIPTION
I'd like to suggest that we remove the following two rules:

- `typedef.variable-declaration` - enforces type definition on local variables

This doesn't seem to gain us much as the [compiler infers the correct type](http://www.typescriptlang.org/play/index.html#src=let%20foo%20%3D%201%3B%0Afoo%20%3D%20%22str%22%3B).
Humans are much worse at this task, for example we have the following declaration in a test somewhere:
```
const itShouldRender: (name: string, template: string, assert: (element: any) => void) => void =
        (name, template, assert) =>
```

- `no-null-keyword` - disallows the use of null

That's fine for an self-sufficient project, but we're building a library. Users and the framework itself will happily supply us with both `null`s and `undefined`s. We need to be able to distinguish between them to act correctly.