### PR TITLE
fix: remove obsolete use-strict TSLint rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -132,11 +132,6 @@
         "variable-declaration": "nospace"
       }
     ],
-    "use-strict": [
-      true,
-      "check-module",
-      "check-function"
-    ],
     "variable-name": [
       true,
       "check-format",


### PR DESCRIPTION
The TypeScript compiler emits those by default starting from version 1.8

See palantir/tslint#678